### PR TITLE
stacks: changes to compute stack

### DIFF
--- a/stacks/config.yaml
+++ b/stacks/config.yaml
@@ -1,7 +1,7 @@
 ---
 common:
   ssh_key_name: vaijab
-  coreos_ami_name: CoreOS-alpha-758.1.0-hvm
+  coreos_ami_name: CoreOS-alpha-766.0.0-hvm
   compute_min_instances: 3
   vpc_cidr: 10.50.0.0/16
   compute_subnets:

--- a/stacks/templates/coreos-compute.yaml
+++ b/stacks/templates/coreos-compute.yaml
@@ -76,8 +76,7 @@ Resources:
           PropagateAtLaunch: true
     UpdatePolicy:
       AutoScalingRollingUpdate:
-        MinInstancesInService: {{ compute_min_instances }}
-        PauseTime: PT30S
+        PauseTime: PT5M
 
   CoreOSComputeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
@@ -118,6 +117,15 @@ Resources:
             update:
               reboot-strategy: 'best-effort'
             units:
+            - name: iptables-restore.service
+              enable: true
+              command: start
+            - name: docker.service
+              drop-ins:
+              - name: 10-opts.conf
+                content: |
+                  [Service]
+                  Environment=DOCKER_OPTS='--iptables="false"'
             - name: etcd2.service
               command: start
               enable: true
@@ -249,3 +257,13 @@ Resources:
           - path: /etc/ssl/certs/platform_ca.pem
             encoding: base64
             content: {{ ca_cert }}
+          - path: /var/lib/iptables/rules-save
+            content: |
+              *filter
+              :INPUT ACCEPT [0:0]
+              :FORWARD ACCEPT [0:0]
+              -A FORWARD -d 169.254.169.254/32 -i docker0 -p tcp -m tcp --dport 80 -j DROP
+              -A FORWARD -i docker0 -p tcp -m tcp --dport 2379 -j DROP
+              :OUTPUT ACCEPT [0:0]
+              COMMIT
+


### PR DESCRIPTION
- bump to latest coreos version
- disable docker iptables management
- isolate containers from etcd and ec2 metadata service fixes #8
- set UpdatePolicy PauseTime to 5 minutes
