### PR TITLE
ca: add kubernetes api service IP to hosts

### DIFF
--- a/ca/kube-apiserver-csr.json
+++ b/ca/kube-apiserver-csr.json
@@ -2,7 +2,8 @@
   "CN": "*.homeoffice.gov.uk",
   "hosts": [
     "localhost",
-    "127.0.0.1"
+    "127.0.0.1",
+    "10.200.0.1"
   ],
   "key": {
    "algo": "rsa",


### PR DESCRIPTION
Allows kubernetes API service IP to be trusted by the cert.
