### PR TITLE
Update docs and supply some scripts (latest s3secrets)

### DIFF
--- a/docs/platform_setup.md
+++ b/docs/platform_setup.md
@@ -6,7 +6,7 @@
 - [AWS cli tools](http://docs.aws.amazon.com/cli/latest/userguide/installing.html)
 - AWS API keys
 - [stacks tool](https://github.com/State/stacks)
-- [cfssl tool](https://github.com/cloudflare/cfssl)
+- [cfssl + cfssljson tool](https://github.com/cloudflare/cfssl)
 
 Below commands could be easily put in a script, but for now, let's understand
 what pieces are needed for the platform and then we can script it.
@@ -26,6 +26,7 @@ $ mkdir -p tmp; cd tmp
 $ export ENV=dev
 $ export KUBE_TOKEN=$(uuidgen)
 $ export KMS_KEY_ID=<replace me>
+$ export AWS_PROFILE=<profile in ~/.aws/credentials >
 ```
 
 
@@ -67,10 +68,10 @@ Make a note of `KUBE_TOKEN` because that's what you will be using to talk to
 kubernetes API for now.
 
 ```bash
-$ aws --profile hod-dsp kms encrypt --key-id ${KMS_KEY_ID} \
+$ aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} \
   --plaintext "$(echo ${KUBE_TOKEN},kube,kube)" \
   --query CiphertextBlob \
-  --output text | base64 -d > tokens.csv.encrypted
+  --output text | base64 --decode > tokens.csv.encrypted
 ```
 
 ```bash
@@ -95,57 +96,57 @@ EOF
 
 * **etcd**
 ```
-$ aws --profile hod-dsp kms encrypt --key-id ${KMS_KEY_ID} \
+$ aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} \
   --plaintext "$(cat etcd.pem)" \
   --query CiphertextBlob \
-  --output text | base64 -d > etcd-crt.pem.encrypted
+  --output text | base64 --decode > etcd-crt.pem.encrypted
 
-$ aws --profile hod-dsp kms encrypt --key-id ${KMS_KEY_ID} \
+$ aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} \
   --plaintext "$(cat etcd-key.pem)" \
   --query CiphertextBlob \
-  --output text | base64 -d > etcd-key.pem.encrypted
+  --output text | base64 --decode > etcd-key.pem.encrypted
 ```
 
 * **vault**
 ```
-$ aws --profile hod-dsp kms encrypt --key-id ${KMS_KEY_ID} \
+$ aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} \
   --plaintext "$(cat vault.pem)" \
   --query CiphertextBlob \
-  --output text | base64 -d > vault-crt.pem.encrypted
+  --output text | base64 --decode > vault-crt.pem.encrypted
 
-$ aws --profile hod-dsp kms encrypt --key-id ${KMS_KEY_ID} \
+$ aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} \
   --plaintext "$(cat vault-key.pem)" \
   --query CiphertextBlob \
-  --output text | base64 -d > vault-key.pem.encrypted
+  --output text | base64 --decode > vault-key.pem.encrypted
 ```
 
 * **kube-apiserver**
 ```
-$ aws --profile hod-dsp kms encrypt --key-id ${KMS_KEY_ID} \
+$ aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} \
   --plaintext "$(cat kube-apiserver.pem)" \
   --query CiphertextBlob \
-  --output text | base64 -d > kube-apiserver-crt.pem.encrypted
+  --output text | base64 --decode > kube-apiserver-crt.pem.encrypted
 
-$ aws --profile hod-dsp kms encrypt --key-id ${KMS_KEY_ID} \
+$ aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} \
   --plaintext "$(cat kube-apiserver-key.pem)" \
   --query CiphertextBlob \
-  --output text | base64 -d > kube-apiserver-key.pem.encrypted
+  --output text | base64 --decode > kube-apiserver-key.pem.encrypted
 ```
 
 * **kubeconfig**
 ```
-$ aws --profile hod-dsp kms encrypt --key-id ${KMS_KEY_ID} \
+$ aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} \
   --plaintext "$(cat kubeconfig)" \
   --query CiphertextBlob \
-  --output text | base64 -d > kubeconfig.encrypted
+  --output text | base64 --decode > kubeconfig.encrypted
 ```
 
 * **auth-policy**
 ```
-$ aws --profile hod-dsp kms encrypt --key-id ${KMS_KEY_ID} \
+$ aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} \
   --plaintext "$(cat ../kube/${ENV}/auth-policy.json)" \
   --query CiphertextBlob \
-  --output text | base64 -d > auth-policy.json.encrypted
+  --output text | base64 --decode > auth-policy.json.encrypted
 ```
 
 
@@ -154,13 +155,13 @@ $ aws --profile hod-dsp kms encrypt --key-id ${KMS_KEY_ID} \
 First we need to make sure that secrets bucket exists.
 
 ```bash
-$ aws --profile hod-dsp s3 mb s3://${ENV}-platform-secrets-eu-west-1
+$ aws --profile ${AWS_PROFILE} s3 mb s3://${ENV}-platform-secrets-eu-west-1
 
 ```
 
 ```bash
 for n in $(ls -1 *.encrypted); do
-  aws --profile hod-dsp s3 cp ${n} s3://${ENV}-platform-secrets-eu-west-1
+  aws --profile ${AWS_PROFILE} s3 cp ${n} s3://${ENV}-platform-secrets-eu-west-1
 done
 ```
 
@@ -170,39 +171,41 @@ done
 $ cd ..; rm -rf tmp
 ```
 
+edit stacks/config.yaml to your requirements
+
 
 ## Launch AWS CloudFormation Stacks
 
 * **First, we need to create infrastructure resources**
 ```
-$ stacks -p hod-dsp create -e ${ENV} -t templates/infra.yaml ${ENV}-infra
+$ stacks -p ${AWS_PROFILE} create -e ${ENV} -t templates/infra.yaml ${ENV}-infra
 ```
 
 * **Wait for the infra stack to be in `CREATE_COMPLETE` state**
 ```
-$ stacks -p hod-dsp list
+$ stacks -p ${AWS_PROFILE} list
 dev-infra  CREATE_COMPLETE
 ```
 
 * **Next step is to create an etcd cluster**
 ```
-stacks -p hod-dsp create -e ${ENV} -t templates/coreos-etcd-volumes.yaml ${ENV}-coreos-etcd-volumes
+stacks -p ${AWS_PROFILE} create -e ${ENV} -t templates/coreos-etcd-volumes.yaml ${ENV}-coreos-etcd-volumes
 ```
 
 Wait for the volumes stack to finish creating, it usually takes less than 30 seconds
 
 ```
-stacks -p hod-dsp create -e ${ENV} -t templates/coreos-etcd.yaml ${ENV}-coreos-etcd
+stacks -p ${AWS_PROFILE} create -e ${ENV} -t templates/coreos-etcd.yaml ${ENV}-coreos-etcd
 ```
 
 * **Once etcd cluster is formed, compute stack can be launched next**
 ```
-stacks -p hod-dsp create -e ${ENV} -t templates/coreos-compute.yaml ${ENV}-coreos-compute
+stacks -p ${AWS_PROFILE} create -e ${ENV} -t templates/coreos-compute.yaml ${ENV}-coreos-compute
 ```
 
-* **Create an ELB for Kubernetes API**
+* **Create an ELB for Kubernetes API**  Pre Requisite : Set up an SSL cert in amazon and setup stacks/config.yaml
 ```
-stacks -p hod-dsp create -e ${ENV} -t templates/kubernetes-elb.yaml ${ENV}-kubernetes-elb
+stacks -p ${AWS_PROFILE} create -e ${ENV} -t templates/kubernetes-elb.yaml ${ENV}-kubernetes-elb
 ```
 
 You will need to attach the ELB to the compute auto scaling group. See
@@ -212,13 +215,13 @@ You will need to attach the ELB to the compute auto scaling group. See
 
 ### Start Vault service
 
-Login to one of the nodes, either etcd or compute, clone this repo and start
+Login to one of the etcd nodes, copy the service file and start
 the services:
 
 ```
-$ ssh -l core -A <hostname or IP>
-$ git clone git@github.com:UKHomeOffice/dsp.git
-$ cd dsp/units/vault
+$ scp -r -i <you ssh key file> dsp/units core@<hostname or IP>
+$ ssh -i <you ssh key file> core@<hostname or IP>
+$ cd units/vault
 $ fleetctl start vault.service
 ```
 
@@ -246,15 +249,15 @@ unsealed automatically.
 
 * **Encrypt the key**
 ```
-$ aws --profile hod-dsp kms encrypt \
+$ aws --profile ${AWS_PROFILE} kms encrypt \
   --key-id ${KMS_KEY_ID} \
   --plaintext "0efc52423a2c31359cb74a91e47b6ccf8df658e0a3c1dfeb64ffbd30b0e45c01" \
-  --query CiphertextBlob --output text | base64 -d > vault-unseal.key.encrypted
+  --query CiphertextBlob --output text | base64 --decode > vault-unseal.key.encrypted
 ```
 
 * **Upload encrypted key to S3 secrets bucket**
 ```
-$ aws --profile hod-dsp \
+$ aws --profile ${AWS_PROFILE} \
   s3 cp vault-unseal.key.encrypted s3://${ENV}-platform-secrets-eu-west-1
 ```
 
@@ -284,6 +287,7 @@ Login to one of the nodes, either etcd or compute, clone this repo and start
 the services:
 
 ```
+scp -r -i <identityfile> dsp/units core@
 $ ssh -l core -A <hostname or IP>
 $ git clone git@github.com:UKHomeOffice/dsp.git
 $ cd dsp/units/kubernetes

--- a/docs/scripts/gencerts.sh
+++ b/docs/scripts/gencerts.sh
@@ -1,0 +1,44 @@
+#!/bin/sh -e
+
+CERTS="kube-apiserver-csr.json vault-csr.json etcd-csr.json"
+
+# XXX doest test bucket exists
+# very buggy 
+if [ "${AWS_PROFILE}" = "" -o "${ENV}" = ""]; then
+	echo "AWS_PROFILE and ENV env vars should be set"
+	exit 1
+fi
+
+if [ ! -e ./ca-config.json ]; then
+	echo "Must be ran in the ca directory. Where ca-config.json is"
+	exit 2
+fi
+
+if [ ! -e ${ENV}/ca-key.pem ]; then 
+	echo "${ENV}/ca-key.pem and ${ENV}/ca.pem should be th elocation of your ca certs@
+	exit 3
+fi
+
+for CERT in ${CERTS}; do 
+	NAME=`echo ${CERT} | sed -e 's/-csr.json//'`
+        cfssl gencert -config=./ca-config.json -ca-key=${ENV}/ca-key.pem -ca=${ENV}/ca.pem -profile=server ${CERT} | cfssljson -bare ${NAME}
+        # XXX this should be a function
+	aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} --plaintext "`cat ${NAME}.pem`" --query CiphertextBlob --output text | base64 --decode > ${NAME}-crt.pem.encrypted
+	aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} --plaintext "`cat ${NAME}-key.pem`" --query CiphertextBlob --output text | base64 --decode > ${NAME}-key.pem.encrypted
+	rm  ${NAME}-key.pem ${NAME}.pem
+done 
+
+
+# XXX this should be a function
+aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} --plaintext "`cat kubeconfig`" --query CiphertextBlob --output text | base64 --decode > kubeconfig.encrypted
+ls -l kubeconfig.encrypted
+echo "Generateing tokens.csv encrypting and uploading"
+aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} --plaintext "$(echo ${KUBE_TOKEN},kube,kube)" --query CiphertextBlob --output text | base64 --decode > tokens.csv.encrypted
+echo " encrypting auth-policy.json and uploading "
+aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} --plaintext "`cat auth-policy.json`" --query CiphertextBlob --output text | base64 --decode > auth-policy.json.encrypted
+
+
+for n in $(ls -1 *.encrypted); do
+  aws --profile ${AWS_PROFILE} s3 cp ${n} s3://${ENV}-platform-secrets-eu-west-1
+  rm ${n}
+done

--- a/docs/scripts/upload-vault-key.sh
+++ b/docs/scripts/upload-vault-key.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+
+if [ "${1}" = "" -o "${AWS_PROFILE}" = "" -o "${KMS_KEY_ID}" = "" ]; then 
+	echo "usage: $0 <key 1>"
+	exit 1
+fi
+if [ "${AWS_PROFILE}" = "" -o "${KMS_KEY_ID}" = "" ]; then 
+	echo " Please set AWS_PROFILE and KMS_KEY_ID Enviornment variables"
+	exit 2
+fi
+
+#XXX assumes the file does not already exist in which case it would overright this is not very secure
+aws --profile ${AWS_PROFILE} kms encrypt --key-id ${KMS_KEY_ID} --plaintext ${1} --query CiphertextBlob --output text | base64 --decode > vault-unseal.key.encrypted
+aws --profile ${AWS_PROFILE} s3 cp vault-unseal.key.encrypted s3://hod-future-dev-platform-secrets-eu-west-1
+rm -f vault-unseal.key.encrypted

--- a/stacks/templates/coreos-etcd.yaml
+++ b/stacks/templates/coreos-etcd.yaml
@@ -194,9 +194,9 @@ Resources:
                 Type=oneshot
                 RemainAfterExit=yes
                 TimeoutStartSec=30
-                Environment="URL=https://github.com/UKHomeOffice/s3secrets/releases/download/v0.0.1/s3secrets-0.0.1-linux-amd64"
+                Environment="URL=https://github.com/UKHomeOffice/s3secrets/releases/download/v0.1.0/s3secrets-0.1.0-linux-amd64"
                 Environment="OUTPUT_FILE=/opt/bin/s3secrets"
-                Environment="MD5SUM=aecf1a0d9c0a113432bb15bb10d16541"
+                Environment="MD5SUM=07205a23f045906564b13efc6a5b4c68"
                 ExecStart=/usr/bin/mkdir -p /opt/bin
                 ExecStart=/usr/bin/bash -c 'until [[ -x ${OUTPUT_FILE} ]] && [[ $(md5sum ${OUTPUT_FILE} | cut -f1 -d" ") == ${MD5SUM} ]]; do wget -O ${OUTPUT_FILE} ${URL} && chmod +x ${OUTPUT_FILE}; done'
             - name: update-ca-certificates.service


### PR DESCRIPTION
Scripts: Add 2 scripts that make the setup from the docs easier (need work)
Template: change coreos-etcd to use the latest version of s3secrets
Documentation: Updated to be inline with using on OSX and fixed where I saw problems

  This is from my experience of setting up a test environment for hod-future ( might have another title)
  It may not be complete.
