### PR TITLE
kube: changes to auth policy

### DIFF
--- a/kube/dev/auth-policy.json
+++ b/kube/dev/auth-policy.json
@@ -1,7 +1,10 @@
 {"user":"dsp"}
 {"user":"vaijab"}
-{"user":"purplebooth", "namespace": "hoapi-catalogue"}
-{"user":"purplebooth", "namespace": "hoapi-catalogue-automatedtest"}
+{"user":"purplebooth"}
+{"user":"wilko55"}
+{"user":"mikeyhu"}
+{"user":"jenkins"}
+{"user":"vamsi-qa"}
 {"user":"skydns", "readonly": true, "resource": "pods"}
 {"user":"skydns", "readonly": true, "resource": "services"}
 {"user":"skydns", "readonly": true, "resource": "endpoints"}


### PR DESCRIPTION
Current (v1.0.5) release of kubernetes does not really support
restricting user access to particular namespace. We're giving users
full access to the cluster until a new kubernetes release (probably
v1.1.x).
