### PR TITLE
Templates: Update to verions 0.1.0 of s3secrets

### DIFF
--- a/stacks/templates/coreos-compute.yaml
+++ b/stacks/templates/coreos-compute.yaml
@@ -243,9 +243,9 @@ Resources:
                 Type=oneshot
                 RemainAfterExit=yes
                 TimeoutStartSec=30
-                Environment="URL=https://github.com/UKHomeOffice/s3secrets/releases/download/v0.0.1/s3secrets-0.0.1-linux-amd64"
+                Environment="URL=https://github.com/UKHomeOffice/s3secrets/releases/download/v0.1.0/s3secrets-0.1.0-linux-amd64"
                 Environment="OUTPUT_FILE=/opt/bin/s3secrets"
-                Environment="MD5SUM=aecf1a0d9c0a113432bb15bb10d16541"
+                Environment="MD5SUM=07205a23f045906564b13efc6a5b4c68"
                 ExecStart=/usr/bin/mkdir -p /opt/bin
                 ExecStart=/usr/bin/bash -c 'until [[ -x ${OUTPUT_FILE} ]] && [[ $(md5sum ${OUTPUT_FILE} | cut -f1 -d" ") == ${MD5SUM} ]]; do wget -q -O ${OUTPUT_FILE} ${URL} && chmod +x ${OUTPUT_FILE}; done'
             - name: update-ca-certificates.service

--- a/stacks/templates/coreos-etcd.yaml
+++ b/stacks/templates/coreos-etcd.yaml
@@ -194,9 +194,9 @@ Resources:
                 Type=oneshot
                 RemainAfterExit=yes
                 TimeoutStartSec=30
-                Environment="URL=https://github.com/UKHomeOffice/s3secrets/releases/download/v0.0.1/s3secrets-0.0.1-linux-amd64"
+                Environment="URL=https://github.com/UKHomeOffice/s3secrets/releases/download/v0.1.0/s3secrets-0.1.0-linux-amd64"
                 Environment="OUTPUT_FILE=/opt/bin/s3secrets"
-                Environment="MD5SUM=aecf1a0d9c0a113432bb15bb10d16541"
+                Environment="MD5SUM=07205a23f045906564b13efc6a5b4c68"
                 ExecStart=/usr/bin/mkdir -p /opt/bin
                 ExecStart=/usr/bin/bash -c 'until [[ -x ${OUTPUT_FILE} ]] && [[ $(md5sum ${OUTPUT_FILE} | cut -f1 -d" ") == ${MD5SUM} ]]; do wget -O ${OUTPUT_FILE} ${URL} && chmod +x ${OUTPUT_FILE}; done'
             - name: update-ca-certificates.service


### PR DESCRIPTION
   This just updates to the latest available version of s3secret for etcd and compute nodes.

(splitting up an existing PR that shall be removed)
