### PR TITLE
stacks: fix MTU 9001 issue

### DIFF
--- a/stacks/templates/coreos-compute.yaml
+++ b/stacks/templates/coreos-compute.yaml
@@ -121,6 +121,32 @@ Resources:
             - name: iptables-restore.service
               enable: true
               command: start
+            - name: 90-mtu.network
+              command: start
+              enable: true
+              content: |
+                [Network]
+                DHCP=v4
+
+                [DHCP]
+                UseMTU=false
+                UseDomains=true
+
+                [Link]
+                MTUBytes=1500
+            - name: systemd-networkd.service
+              command: start
+              enable: true
+            - name: set-eth0-mtu.service
+              command: start
+              content: |
+                [Unit]
+                Description=Set eth0 MTU
+
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                ExecStart=/usr/bin/ip link set mtu 1500 dev eth0
             - name: docker.service
               drop-ins:
               - name: 10-opts.conf

--- a/stacks/templates/coreos-etcd.yaml
+++ b/stacks/templates/coreos-etcd.yaml
@@ -103,6 +103,32 @@ Resources:
             update:
               reboot-strategy: 'off'
             units:
+            - name: 90-mtu.network
+              command: start
+              enable: true
+              content: |
+                [Network]
+                DHCP=v4
+
+                [DHCP]
+                UseMTU=false
+                UseDomains=true
+
+                [Link]
+                MTUBytes=1500
+            - name: systemd-networkd.service
+              command: start
+              enable: true
+            - name: set-eth0-mtu.service
+              command: start
+              content: |
+                [Unit]
+                Description=Set eth0 MTU
+
+                [Service]
+                Type=oneshot
+                RemainAfterExit=yes
+                ExecStart=/usr/bin/ip link set mtu 1500 dev eth0
             - name: fleet.service
               command: start
               enable: true


### PR DESCRIPTION
Larger new gen ec2 instances support MTU 9001, while many other
instances still only support MTU 1500. Due to MTU size mismatch, some
weird network behaviour can occur. Setting MTU to 1500 explicitly
solves this problem.
