### PR TITLE
Template: Fix minor typo in docker line missing --

### DIFF
--- a/stacks/templates/coreos-compute.yaml
+++ b/stacks/templates/coreos-compute.yaml
@@ -128,7 +128,7 @@ Resources:
                   [Service]
                   # TODO: remove below line once https://github.com/coreos/bugs/issues/483 is fixed
                   ExecStart=
-                  ExecStart=/usr/lib/coreos/dockerd daemon --host=fd:// --log-driver=json-file $DOCKER_OPTS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
+                  ExecStart=/usr/lib/coreos/dockerd --daemon --host=fd:// --log-driver=json-file $DOCKER_OPTS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
                   Environment=DOCKER_OPTS='--iptables="false"'
             - name: etcd2.service
               command: start


### PR DESCRIPTION
```
When building a stack I found docker would not start onto is second config once kubernetes was deployed
```

  I tracked it down to this and everything seems to work.
