### PR TITLE
Added Jon's aws_userssync

### DIFF
--- a/stacks/config.yaml
+++ b/stacks/config.yaml
@@ -1,5 +1,6 @@
 ---
 common:
+  aws_groups_csv: Devops
   ssh_key_name: vaijab
   coreos_ami_name: CoreOS-alpha-808.0.0-hvm
   compute_min_instances: 5

--- a/stacks/templates/coreos-compute.yaml
+++ b/stacks/templates/coreos-compute.yaml
@@ -39,6 +39,13 @@ Resources:
           Effect: Allow
           Action:
             - 's3:List*'
+        - Resource: "arn:aws:iam::*"
+          Effect: "Allow"
+          Action:
+            - "iam:GetGroup"
+            - "iam:GetSSHPublicKey"
+            - "iam:GetUser"
+            - "iam:ListSSHPublicKeys"
 
   CoreOSComputeScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -118,6 +125,21 @@ Resources:
             update:
               reboot-strategy: 'off'
             units:
+            - name: aws-usersync.service
+              command: start
+              content: |
+                [Unit]
+                Description=Sync users from IAM
+
+                [Service]
+                TimeoutStartSec=300
+                Restart=always
+                Environment="URL=https://github.com/UKHomeOffice/aws_usersync/releases/download/v0.1.0/aws_usersync-0.1.0-linux-amd64"
+                Environment="OUTPUT_FILE=/opt/bin/aws_usersync"
+                Environment="MD5SUM=bd7e299597a38cd9c64f202d9f16e923"
+                ExecStartPre=/usr/bin/mkdir -p /opt/bin
+                ExecStartPre=/usr/bin/bash -c 'until [[ -x ${OUTPUT_FILE} ]] && [[ $(md5sum ${OUTPUT_FILE} | cut -f1 -d" ") == ${MD5SUM} ]]; do wget -q -O ${OUTPUT_FILE} ${URL} && chmod +x ${OUTPUT_FILE} ; done'
+                ExecStart=/opt/bin/aws_usersync -o=false -i=5 -g="{{ aws_groups_csv }}" -I="root,core,vault"
             - name: iptables-restore.service
               enable: true
               command: start

--- a/stacks/templates/coreos-etcd.yaml
+++ b/stacks/templates/coreos-etcd.yaml
@@ -42,6 +42,13 @@ Resources:
           Effect: Allow
           Action:
             - 's3:List*'
+        - Resource: "arn:aws:iam::*"
+          Effect: "Allow"
+          Action:
+            - "iam:GetGroup"
+            - "iam:GetSSHPublicKey"
+            - "iam:GetUser"
+            - "iam:ListSSHPublicKeys"
 
 {%- for node in etcd_nodes %}
   # This resource can be replaced by just changing node name in the config file
@@ -103,6 +110,21 @@ Resources:
             update:
               reboot-strategy: 'off'
             units:
+            - name: aws-usersync.service
+              command: start
+              content: |
+                [Unit]
+                Description=Sync users from IAM
+
+                [Service]
+                TimeoutStartSec=300
+                Restart=always
+                Environment="URL=https://github.com/UKHomeOffice/aws_usersync/releases/download/v0.1.0/aws_usersync-0.1.0-linux-amd64"
+                Environment="OUTPUT_FILE=/opt/bin/aws_usersync"
+                Environment="MD5SUM=bd7e299597a38cd9c64f202d9f16e923"
+                ExecStartPre=/usr/bin/mkdir -p /opt/bin
+                ExecStartPre=/usr/bin/bash -c 'until [[ -x ${OUTPUT_FILE} ]] && [[ $(md5sum ${OUTPUT_FILE} | cut -f1 -d" ") == ${MD5SUM} ]]; do wget -q -O ${OUTPUT_FILE} ${URL} && chmod +x ${OUTPUT_FILE} ; done'
+                ExecStart=/opt/bin/aws_usersync -o=false -i=5 -g="{{ aws_groups_csv }}" -I="root,core,vault"
             - name: 90-mtu.network
               command: start
               enable: true


### PR DESCRIPTION
Added @jon-shanks [aws_usersync](https://github.com/UKHomeOffice/aws_usersync) as unit. The group "Devops" has been created in the DSP AWS account.

Tested as [update to NFIDD](https://github.com/UKHomeOffice/FDCS_devops/commit/54d67850be21ce7aedc2d2d4195767f43ea46691) in dev and prod.

Note only one key per user...

Requires a restart of etcd nodes and a rolling update of compute.
