### PR TITLE
Change LB to TCP rather than HTTPS

### DIFF
--- a/stacks/templates/kubernetes-elb.yaml
+++ b/stacks/templates/kubernetes-elb.yaml
@@ -50,16 +50,9 @@ Resources:
         Timeout: 30
       Listeners:
       - LoadBalancerPort: 443
-        Protocol: HTTPS
+        Protocol: TCP
         InstancePort: 6443
         InstanceProtocol: HTTPS
-        SSLCertificateId:
-          'Fn::Join':
-          - ''
-          -
-            - 'arn:aws:iam::'
-            - Ref: AWS::AccountId
-            - ':{{ platform_tls_cert_name }}'
       Tags:
       - Key: Name
         Value: {{ env }}-kubernetes-elb


### PR DESCRIPTION
In order to allow `kubectl exec` we need to have websocket support at the LB. This is achieved by changing the LB to TCP rather than HTTPS.

We need `kubectl exec` because it's the only real way developers can debug their containers on the cluster, in absence of logs or server access.

@vaijab @jon-shanks I'm not sure what certificate Kubernetes is serving, so this might cause certificate errors.
