### PR TITLE
Increase number of open files limit for kube proxy

### DIFF
--- a/units/kubernetes/kube-proxy.service
+++ b/units/kubernetes/kube-proxy.service
@@ -3,6 +3,7 @@ Description=Kubernetes Proxy
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
 [Service]
+LimitNOFILE=10240
 RuntimeDirectory=kube-proxy
 RuntimeDirectoryMode=0700
 EnvironmentFile=/etc/s3secrets


### PR DESCRIPTION
It seems that kube-proxy leaks FDs (connections), hopefully 10240 is
going to be enough time for the old ones to timeout.

fixes #70
fixes #72

/cc @PurpleBooth @gambol99 @jon-shanks @timgent
