### PR TITLE
iptables rules fix

### DIFF
--- a/stacks/templates/coreos-compute.yaml
+++ b/stacks/templates/coreos-compute.yaml
@@ -295,6 +295,17 @@ Resources:
                 TimeoutStartSec=300
                 ExecStart=/usr/sbin/update-ca-certificates
           write_files:
+          # Note: the newline post COMMIT is required by iptables-restore
+          - path: /var/lib/iptables/rules-save
+            content: |
+              *filter
+              :INPUT ACCEPT [0:0]
+              :FORWARD ACCEPT [0:0]
+              -A FORWARD -d 169.254.169.254/32 -i docker0 -p tcp -m tcp --dport 80 -j DROP
+              -A FORWARD -i docker0 -p tcp -m tcp --dport 2379 -j DROP
+              :OUTPUT ACCEPT [0:0]
+              COMMIT
+              
           - path: /etc/s3secrets
             content: |
               BUCKET_NAME={{ secrets_bucket_name }}
@@ -305,12 +316,3 @@ Resources:
           - path: /etc/ssl/etcd/platform_ca.pem
             encoding: base64
             content: {{ ca_cert }}
-          - path: /var/lib/iptables/rules-save
-            content: |
-              *filter
-              :INPUT ACCEPT [0:0]
-              :FORWARD ACCEPT [0:0]
-              -A FORWARD -d 169.254.169.254/32 -i docker0 -p tcp -m tcp --dport 80 -j DROP
-              -A FORWARD -i docker0 -p tcp -m tcp --dport 2379 -j DROP
-              :OUTPUT ACCEPT [0:0]
-              COMMIT


### PR DESCRIPTION
The last change I did caused an issue with iptables-restore service. Vaidas informed it's due to a newline removed at the end of the file; no doubt removed by my editor on saving.
- adding the newline back to iptables.rules
- it's probably best we move up the chain to ensure it doesn't have again, as quite a few people using sublime, atom etc etc will have this setting by default  
