### PR TITLE
Create a file in coreos with aws environment info

### DIFF
--- a/stacks/templates/coreos-compute.yaml
+++ b/stacks/templates/coreos-compute.yaml
@@ -310,6 +310,10 @@ Resources:
             content: |
               BUCKET_NAME={{ secrets_bucket_name }}
               AWS_REGION={{ region }}
+          - path: /etc/aws-environment
+            content: |
+              ENVIRONMENT={{ env }}
+              AWS_REGION={{ region }}
           - path: /etc/ssl/certs/platform_ca.pem
             encoding: base64
             content: {{ ca_cert }}

--- a/stacks/templates/coreos-etcd.yaml
+++ b/stacks/templates/coreos-etcd.yaml
@@ -250,6 +250,10 @@ Resources:
             content: |
               BUCKET_NAME={{ secrets_bucket_name }}
               AWS_REGION={{ region }}
+          - path: /etc/aws-environment
+            content: |
+              ENVIRONMENT={{ env }}
+              AWS_REGION={{ region }}
           - path: /etc/vault.hcl
             content: |
               backend "etcd" {


### PR DESCRIPTION
This can be quite useful for an application which needs to know which
region they are running in. One example is logstash - it runs in a
container via fleet unit and it needs to know which AWS region to
connect to to push logs.
