### PR TITLE
units: fix kube proxy logging

### DIFF
--- a/units/kubernetes/kube-proxy.service
+++ b/units/kubernetes/kube-proxy.service
@@ -3,6 +3,8 @@ Description=Kubernetes Proxy
 Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
 [Service]
+StandardOutput=null
+StandardError=null
 LimitNOFILE=10240
 RuntimeDirectory=kube-proxy
 RuntimeDirectoryMode=0700


### PR DESCRIPTION
Well this is a workaround. kube proxy spits way too many messages for
journal to handle (it's possible that journal has bugs) which makes
journal to lock up.

See https://github.com/coreos/bugs/issues/909

I believe that kube proxy logging issues have been resolved in the next
release.
