### PR TITLE
[ca/kubeapi]

### DIFF
--- a/ca/kube-apiserver-csr.json
+++ b/ca/kube-apiserver-csr.json
@@ -3,7 +3,9 @@
   "hosts": [
     "localhost",
     "127.0.0.1",
-    "10.200.0.1"
+    "10.200.0.1",
+    "*.notprod.homeoffice.gov.uk",
+    "*.dsp.digital.homeoffice.gov.uk"
   ],
   "key": {
    "algo": "rsa",


### PR DESCRIPTION
- fixes the kubectl exec issue
- since dsp is no longer the generic repo, we can be dsp specific from now on
