### PR TITLE
New users and new namespace

### DIFF
--- a/kube/dev/auth-policy.json
+++ b/kube/dev/auth-policy.json
@@ -1,9 +1,17 @@
 {"user":"dsp"}
 {"user":"jenkins"}
+{"user":"jshanks"}
 {"user":"mikeyhu"}
+{"user":"mmiller"}
 {"user":"purplebooth"}
 {"user":"rohithj"}
 {"user":"skydns"}
 {"user":"vaijab"}
 {"user":"vamsi-qa"}
 {"user":"wilko55"}
+{"user":"easternbloc"}
+{"user":"joechapman"}
+{"user":"joe.flintham"}
+{"user":"daniel.martin"}
+{"user":"paul.miles"}
+

--- a/kube/dev/namespaces/rotm.yaml
+++ b/kube/dev/namespaces/rotm.yaml
@@ -1,0 +1,6 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: rotm
+  labels:
+    name: rotm


### PR DESCRIPTION
We should try to keep auth-policy.json in sync with what we actually
have in s3 bucket.

Add new ROTM namespace for ROTM project.
