### PR TITLE
Request port range 30400 - 30499

### DIFF
--- a/docs/apps_deployment.md
+++ b/docs/apps_deployment.md
@@ -41,6 +41,7 @@ are
 BRP           | 30000-30099 
 BRP Mock API  | 30100-30199
 API Catalogue | 30300-30399   
+OTM           | 30400-30499
 
 Please create a new pull request to request a range.
 


### PR DESCRIPTION
This request is for the migration of Reporting Online Terrorist Materials (ROTM) to dsp
