### PR TITLE
Put default limit on log sizes

### DIFF
--- a/stacks/templates/coreos-compute.yaml
+++ b/stacks/templates/coreos-compute.yaml
@@ -159,7 +159,7 @@ Resources:
               - name: 10-opts.conf
                 content: |
                   [Service]
-                  Environment=DOCKER_OPTS='--iptables="false"'
+                  Environment=DOCKER_OPTS='--iptables="false" --log-opt max-size=100m --log-opt max-file=1'
             - name: etcd2.service
               command: start
               enable: true


### PR DESCRIPTION
Container logs should be limited in size and number. Doesn't need to be very large as logs go to cloudwatch for analysis. Suggestion here is 30mb, up to 3 logs. Open to suggestions!
