### PR TITLE
firewall access for exec and logs commands

### DIFF
--- a/stacks/templates/infra.yaml
+++ b/stacks/templates/infra.yaml
@@ -57,6 +57,11 @@ Resources:
           FromPort: 22
           ToPort: 22
 {%- endfor %}
+        # The kube-api requires access to the kubelet on this port to handle exec and logs kubectl commands
+        - IpProtocol: tcp
+          SourceSecurityGroupId: {Ref: SecureDefaultSG}
+          FromPort: 10250
+          ToPort: 10250
       Tags:
         - Key: Name
           Value: {{ env }}-compute-default


### PR DESCRIPTION
[stacks/infra]
- post moving the api to etcd need to open up port 10250 to allow for exec and logs access
