### PR TITLE
sysdig version update

### DIFF
--- a/units/misc/sysdig.service
+++ b/units/misc/sysdig.service
@@ -7,7 +7,7 @@ Requires=docker.service
 TimeoutStartSec=0
 EnvironmentFile=/etc/aws-environment
 EnvironmentFile=/etc/s3secrets
-Environment="DOCKER_IMAGE_TAG=alpha"
+Environment="DOCKER_IMAGE_TAG=0.3.0"
 Environment="COLLECTOR=collector-staging2.sysdigcloud.com"
 Environment="ACCESS_KEY=db25971c-5059-44ba-855f-50c672ec3d4e"
 Environment="TAGS=platform:dsp,region=eu-west-1"


### PR DESCRIPTION
summary: moving to the latest release of sysdig as there was a bug with k8s in the alpha for 1.0.6

[units/misc]
- updating to the latest release of sysdig
