### PR TITLE
coreos update

### DIFF
--- a/stacks/config.yaml
+++ b/stacks/config.yaml
@@ -1,6 +1,6 @@
 ---
 common:
-  coreos_ami_name: CoreOS-alpha-815.0.0-hvm
+  coreos_ami_name: CoreOS-alpha-845.0.0-hvm
   compute_min_instances: 5
   compute_pause_time: PT5M
   vpc_cidr: 10.50.0.0/16


### PR DESCRIPTION
summary: I'm rolling out the path isolation to dsp dev, so figured i'd do this at the sametime

[stacks/config]
- updating the version of coreos to 845
