### PR TITLE
Request for accounts for SO team developers

### DIFF
--- a/kube/dev/auth-policy.json
+++ b/kube/dev/auth-policy.json
@@ -17,4 +17,8 @@
 {"user":"paul.miles"}
 {"user":"pentest1", "namespace": "pentest1" }
 {"user":"pentest2", "namespace": "pentest2" }
-
+{"user":"brendan.butler"}
+{"user":"benjamin.diggle"}
+{"user":"geoff.martin"}
+{"user":"mark.torrens"}
+{"user":"ramesh.sukka"}


### PR DESCRIPTION
Would it be possible to create accounts for the following SO developers, please?

Brendan Butler - brendan.butler@digital.homeoffice.gov.uk
Ben Diggle - benjamin.diggle@digital.homeoffice.gov.uk
Geoff Martin - geoff.martin@digital.homeoffice.gov.uk
Mark Torrens - mark.torrens@digital.homeoffice.gov.uk
Ramesh Sukka - ramesh.sukka@digital.homeoffice.gov.uk 

Thanks
