### PR TITLE
Increase TCP timeout for docker workers elb

### DIFF
--- a/stacks/templates/docker-workers.yaml
+++ b/stacks/templates/docker-workers.yaml
@@ -44,6 +44,8 @@ Resources:
         Interval: 30
         Timeout: 5
         UnhealthyThreshold: 2
+      ConnectionSettings:
+        IdleTimeout: 1800
       ConnectionDrainingPolicy:
         Enabled: true
         Timeout: 30


### PR DESCRIPTION
AWS ELB has a TCP connection timeout of 60 seconds, which means if there
is no activity (no output, etc) coming from docker host via an ELB, the
ELB terminates the connection. And the way drone behaves is a bit
fragile, because as soon as it sees a connection closed, it starts to
terminate containers and to clean up.
