### PR TITLE
Increase space to prevent diskspace issues

### DIFF
--- a/stacks/templates/coreos-compute.yaml
+++ b/stacks/templates/coreos-compute.yaml
@@ -99,7 +99,7 @@ Resources:
       BlockDeviceMappings:
         - DeviceName: "/dev/xvda"
           Ebs:
-            VolumeSize: "30"
+            VolumeSize: "200"
             DeleteOnTermination: true
             VolumeType: "gp2"
       UserData:


### PR DESCRIPTION
@vaijab @gambol99 we are out of disk space for various pods which is blocking builds for srrs.

```
lmarshall@ip-10-50-1-80 ~ $ df
Filesystem     1K-blocks     Used Available Use% Mounted on
devtmpfs        16460964        0  16460964   0% /dev
tmpfs           16475764        0  16475764   0% /dev/shm
tmpfs           16475764     3604  16472160   1% /run
tmpfs           16475764        0  16475764   0% /sys/fs/cgroup
/dev/xvda9      28056904 27781372         0 100% /
/dev/xvda3       1007760   535156    420588  56% /usr
tmpfs           16475764        0  16475764   0% /media
tmpfs           16475764        0  16475764   0% /tmp
/dev/xvda1        130798    65878     64920  51% /boot
/dev/xvda6        110576       60    101344   1% /usr/share/oem
```
