### PR TITLE
Remove uneeded acme section from certificate

### DIFF
--- a/docs/how-to-docs/cert-manager.md
+++ b/docs/how-to-docs/cert-manager.md
@@ -287,13 +287,6 @@ spec:
   commonName: mysite.example.com
   dnsNames:
   - example.com
-  acme:
-    config:
-    - dns01:
-        provider: route53
-      domains:
-      - mysite.example.com
-      - example.com
 ```
 
 Or via ingress you would use


### PR DESCRIPTION
This was left over from a previous version and it no longer works (and isn't needed)